### PR TITLE
Handle the fullscreen shortcut (F) as long as user input is not required in a form field

### DIFF
--- a/twitch-player-plus.user.js
+++ b/twitch-player-plus.user.js
@@ -66,8 +66,20 @@ function applyFixes() {
     checkForQualityOptions()
 
     // Bind F key to toggle fullscreen
-    html5Player.keypress(function(e){
-        if(e.which === 102) $('.js-control-fullscreen').click();
+    $('body').keypress(function(e) {
+      if (e.which === 102) {
+        // fallback to event.target just in case
+        var el = document.activeElement || e.target;
+        var t  = (el && el.tagName.toLowerCase()) || '';
+
+        // pass through to elements that take keyboard input
+        if (/(input|textarea|select)/.test(t)) {
+            return true;
+        }
+
+        $('.js-control-fullscreen').click();
+        return false;
+      }
     });
 }
 

--- a/twitch-player-plus.user.js
+++ b/twitch-player-plus.user.js
@@ -63,7 +63,7 @@ function applyFixes() {
     // Hide options if there are no transcoders
     setInterval(checkForQualityOptions, 5000);
     // Remove initially, otherwise there's an empty space for a bit
-    checkForQualityOptions()
+    checkForQualityOptions();
 
     // Bind F key to toggle fullscreen
     $('body').keypress(function(e) {


### PR DESCRIPTION
A simple method of testing for the tag name of the currently focused element is used to detect whether the F key can be safely handled for the Fullscreen shortcut.

There may be a better trick to do this, I have no idea. Initially I meant to use event.target in a manner similar to event delegation. Event.target reveals the focused element that initially receives the keyboard event, even though the listener is attached on a parent element such as the page body.

Then a quick Google search revealed document.activeElement and I figured I'd use that instead, and event.target as fallback (old browsers). The first is not restricted to focusable elements AFAIK.

The method can potentially be handled for any other types of shortcuts, with the listener being on the body. Testing other key codes for example, with the form field element check remaining the same logic for all other shortcuts.

Anyway feel free to hack / remove / or even cancel this pull request if you don't want it. I just thought I'd finally learn how to do a pull request :)  No problemo.
