### PR TITLE
Video stats overhaul

### DIFF
--- a/twitch-player-plus.user.js
+++ b/twitch-player-plus.user.js
@@ -20,7 +20,7 @@ var waitForPlayerReadyTimer = setInterval(function() {
         clearInterval(waitForPlayerReadyTimer);
       }
     }
-}, 1000);
+}, 100);
 
 function applyFixes() {
     // Sticky volume slider
@@ -44,7 +44,6 @@ function applyFixes() {
       "-webkit-appearance": "none",
       cursor: "pointer",
     });
-    console.log(qualityOptions.find("> option"));
     qualityOptions.find("> option").css({
       background: "black",
       padding: "0 5px",
@@ -52,12 +51,10 @@ function applyFixes() {
       fontWeight: "normal",
     });
     qualityOptions.mouseover(function() {
-        $(this).css("color","#a991d4");
-        $(this).find("> option").css({
-          color: "white",
-        });
+      $(this).css("color","#a991d4");
+      $(this).find("> option").css("color", "white");
     }).mouseout(function() {
-        $(this).css("color","white");
+      $(this).css("color","white");
     });
 
     // Remove remaining label
@@ -77,7 +74,7 @@ function applyFixes() {
 
         // pass through to elements that take keyboard input
         if (/(input|textarea|select)/.test(t)) {
-            return true;
+          return true;
         }
 
         $('.js-control-fullscreen').click();

--- a/twitch-player-plus.user.js
+++ b/twitch-player-plus.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name       Twitch Player Plus
 // @namespace  http://twitch.tv/ehsankia
-// @version    0.8
+// @version    0.9
 // @description  Various tweaks to the Twitch HTML5 player UI
 // @match      http://www.twitch.tv/*
 // @match      http://player.twitch.tv/*
@@ -81,6 +81,34 @@ function applyFixes() {
         return false;
       }
     });
+
+    // Add latency status under Live icon
+    var liveIcon = $('.player-livestatus__online');
+    liveIcon.append("<div class='lag-status'></div>");
+    $('.lag-status').css({width: "60px", marginLeft: "-20px", textAlign: "center"});
+    $('a.js-stats-toggle')[0].click();
+    $('.js-playback-stats').attr('data-state', 'off');
+    setInterval(updateLatency, 1000);
+
+    // Remove old stats button and add new one
+    $('.player-menu__item--stats').css('display', 'none');
+    $('.js-control-fullscreen').before(" \
+      <button type='button' class='player-button js-custom-stats-toggle'> \
+        <span class='player-tip' data-tip='Video Stats'></span> \
+        <svg id='icon-stats' viewBox='0 0 1024 1024' style='width: 16px; fill: white; margin: 1px 6px;'> \
+          <path d='M960 0h-896c-35.328 0-64 28.672-64 64v640c0 35.328 28.672 64 64 64h256l-128 256h32l230.4-256h115.2l230.4 256h32l-128-256h256c35.328 0 64-28.672 64-64v-640c0-35.328-28.672-64-64-64zM960 672c0 17.696-14.304 32-32 32h-832c-17.696 0-32-14.304-32-32v-576c0-17.696 14.304-32 32-32h832c17.696 0 32 14.304 32 32v576zM668.096 500.192l-144.672-372.128-158.016 297.28-88.192-90.72-149.216 92.992 42.112 24.256 95.616-59.584 115.36 118.784 133.6-251.296 147.712 380.128 125.984-265.216 51.328 109.248 56.288-9.44-107.328-228.224-120.576 253.92z'></path> \
+        </svg> \
+      </button>");
+    $('.js-custom-stats-toggle').mouseover(function() {
+      $(this).find('> svg').css("fill","#a991d4");
+    }).mouseout(function() {
+      $(this).find('> svg').css("fill","white");
+    }).click(function(){
+      var prev = $('.js-playback-stats').attr('data-state');
+      var state = prev === 'off' ? 'on' : 'off';
+      $('.js-playback-stats').attr('data-state', state);
+    });
+
 }
 
 function checkForQualityOptions() {
@@ -90,6 +118,13 @@ function checkForQualityOptions() {
   } else {
     qualityOptions.css('display', 'none');
   }
+}
+
+function updateLatency() {
+    var lat = $('.js-stat-hls-latency-broadcaster').text();
+    if (lat.length !== 0) {
+      $('.lag-status').text(lat + ' sec.');
+    }
 }
 
 GM_addStyle(".js-quality:focus { outline: none; }");


### PR DESCRIPTION
1. Moved the stats button from the inside menu to the main bar, with some SVG icon.
   Not quite sold on the icon yet, just took one from here: https://icomoon.io/app/#/select
   I'd be open to suggestions for a different icon.
2. Made it so latency to broadcaster is always showing in the top right corner under live.
   This is a bit of a subjective change, and down the live I'd be open to adding options to
   toggling some of this optimizations off. Also, to achieve this, I open and hide the stats
   menu, which starts pulling stats every second. I'm not sure what sort of performance
   impact this can have, having stats being pulled all the time in the background.

Lastly, these changes are also made in VODs. Seems to work fine, but we may want
to split the behaviors/tweaks depending on which mode we are in down the road.

Any extra thoughts before we merge this? Can you guys test it a bit?
