### PR TITLE
Fix typo which causes undeclared reference, and breaks a feature

### DIFF
--- a/twitch-player-plus.user.js
+++ b/twitch-player-plus.user.js
@@ -81,7 +81,7 @@ function applyFixes() {
       //seek to previous position and keep track of the position
       var oldTime = GM_getValue("seek_" + vodID);
       if (oldTime !== undefined) {
-        oldTime = parseFloat(oldtime);
+        oldTime = parseFloat(oldTime);
         window.eval('flashBackend.videoSeek(' + oldTime + ');');
       }
       setTimeout(function() {


### PR DESCRIPTION
The typo caused an undeclared reference, and prevented the seek position of a VOD to be restored (my favourite feature =)).
